### PR TITLE
Remove accidentally leftover debugging

### DIFF
--- a/src/main/java/rtg/world/gen/structure/StructureOceanMonumentRTG.java
+++ b/src/main/java/rtg/world/gen/structure/StructureOceanMonumentRTG.java
@@ -80,7 +80,7 @@ public class StructureOceanMonumentRTG extends StructureOceanMonument {
         if (i == k && j == l) {
             BiomeGenBase bg = this.worldObj.getWorldChunkManager().getBiomeGenerator(new BlockPos(i * 16 + 8, 64, j * 16 + 8), (BiomeGenBase) null);
 
-            if (bg.biomeID == RealisticBiomeVanillaBase.deepOcean.biomeID || bg.biomeID == RealisticBiomeVanillaBase.ocean.biomeID ) {
+            if (bg.biomeID == RealisticBiomeVanillaBase.deepOcean.biomeID ) {
 
                 boolean flag = this.areBiomesViable(i * 16 + 8, j * 16 + 8, 29, biomes);
 

--- a/src/main/java/rtg/world/gen/terrain/TerrainBase.java
+++ b/src/main/java/rtg/world/gen/terrain/TerrainBase.java
@@ -14,7 +14,7 @@ public class TerrainBase
 
     public TerrainBase(float base) {
         this.base = base;
-        this.minOceanFloor = 10f;
+        this.minOceanFloor = 30f;
     }
 
     public static final float above(float limited, float limit) {


### PR DESCRIPTION
monuments should only generate in deep oceans.
oceans should NOT go down to y=10
this might actually be part of the issue with #10... further testing required